### PR TITLE
Walmart shop streamlit_UI

### DIFF
--- a/grocery_DB/streamlit_UI
+++ b/grocery_DB/streamlit_UI
@@ -1,0 +1,247 @@
+import streamlit as st
+import requests
+import PyPDF2
+import io
+
+# --------------------------------------------------------------------
+# Basic page config & Walmart-like CSS
+# --------------------------------------------------------------------
+st.set_page_config(
+    page_title="Walmart Recipe & Preferences (Cached)",
+    page_icon=":shopping_cart:",
+    layout="centered"
+)
+
+custom_css = """
+<style>
+body {
+    background-color: #fff;
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+}
+[data-testid="stHeader"] {
+    background-color: #007dc6;
+}
+h1, h2, h3, h4, h5, h6 {
+    color: #007dc6;
+}
+.stButton > button {
+    background-color: #007dc6 !important;
+    color: #fff !important;
+    border-radius: 4px !important;
+    border: none !important;
+}
+[data-testid="stSidebar"] {
+    background-color: #f3f4f6;
+}
+p, div, label, span {
+    color: #333;
+}
+</style>
+"""
+st.markdown(custom_css, unsafe_allow_html=True)
+
+st.title("Walmart-Style Recipe & Product Preferences (Cached)")
+
+# --------------------------------------------------------------------
+# 1. OPTIONAL USERNAME / LOGIN
+# --------------------------------------------------------------------
+if "user_data" not in st.session_state:
+    st.session_state.user_data = {}  # holds multiple users' settings
+username = st.text_input("Enter your username to save/load preferences:")
+if username:
+    if username not in st.session_state.user_data:
+        st.session_state.user_data[username] = {}
+    user_prefs = st.session_state.user_data[username]
+    st.subheader(f"Welcome, {username}!")
+
+# --------------------------------------------------------------------
+# 2. Caching the PDF Parsing
+#    We'll create a function to parse a PDF using PyPDF2.
+#    @st.cache_data ensures we only re-parse if the file changes.
+# --------------------------------------------------------------------
+@st.cache_data
+def parse_pdf_file(file_bytes: bytes) -> str:
+    pdf_reader = PyPDF2.PdfReader(io.BytesIO(file_bytes))
+    text_chunks = []
+    for page in pdf_reader.pages:
+        text_chunks.append(page.extract_text())
+    return "\n".join(text_chunks)
+
+# --------------------------------------------------------------------
+# 3. File Uploader (PDF/TXT)
+# --------------------------------------------------------------------
+st.header("Upload a Recipe File (PDF or TXT)")
+uploaded_file = st.file_uploader(
+    "Upload your recipe in PDF or text form",
+    type=["pdf", "txt"]
+)
+
+recipe_text = ""
+ingredients_found = []
+
+if uploaded_file is not None:
+    file_type = uploaded_file.type
+    file_bytes = uploaded_file.read()
+
+    if file_type == "application/pdf":
+        # Parse with our cached function
+        recipe_text = parse_pdf_file(file_bytes)
+    elif file_type == "text/plain":
+        # For text files, we don't expect repeated heavy parsing,
+        # but you could also cache if they're large.
+        recipe_text = file_bytes.decode("utf-8", errors="replace")
+
+    # Simple parse: look for lines that mention "ingredient(s)"
+    lines = recipe_text.splitlines()
+    for line in lines:
+        lower_line = line.lower()
+        if "ingredient" in lower_line:
+            ingredients_found.append(line.strip())
+
+    if recipe_text:
+        st.subheader("Extracted Recipe Text")
+        st.write(recipe_text)
+
+    if ingredients_found:
+        st.subheader("Possible Ingredient Section(s)")
+        for idx, ing_line in enumerate(ingredients_found, start=1):
+            st.write(f"{idx}. {ing_line}")
+    else:
+        if recipe_text:
+            st.info("No obvious lines containing 'ingredient' found.")
+        else:
+            st.info("No recipe text extracted yet.")
+
+# --------------------------------------------------------------------
+# 4. Basic Walmart API Search (Mocked)
+# --------------------------------------------------------------------
+st.header("Walmart API Search")
+
+search_fields = [
+    "product_id",
+    "itemid",
+    "Departments",
+    "Price",
+    "Brand",
+    "FulfillmentSpeed",
+    "Availability",
+    "WalmartCashOffers",
+    "CustomerRating",
+    "Form",
+    "FoodCondition",
+    "Flavor",
+    "MeatType",
+    "NutritionalContent",
+    "SpecialDietNeeds",
+    "PreparationMethod",
+    "Container",
+    "PackagedMealType",
+    "Category",
+    "SizeDescriptor",
+    "Retailer",
+    "Gifting",
+    "BenefitPrograms"
+]
+
+chosen_field = st.selectbox("Choose a field to search by:", search_fields)
+search_value = st.text_input("Enter the search value:")
+search_button = st.button("Search Walmart API")
+
+if search_button and search_value:
+    st.write(f"Searching Walmart's Affiliate API for `{chosen_field} = {search_value}` ...")
+    # Normally: do requests.get(...) with your real API key
+    mock_response = {
+        "query": search_value,
+        "items": [
+            {"itemId": 123456, "name": f"Mock Product for {search_value}", "salePrice": 3.99},
+            {"itemId": 789012, "name": f"Another Mock {search_value} Product", "salePrice": 5.49}
+        ]
+    }
+    st.json(mock_response)
+    st.success("Data fetched (mock). Integrate your real API key for live results!")
+
+# --------------------------------------------------------------------
+# 5. User Preferences (Sliders / Selectboxes)
+# --------------------------------------------------------------------
+st.header("Set & Save Your Walmart Attribute Preferences")
+
+if username:
+    if "field_values" not in user_prefs:
+        user_prefs["field_values"] = {}
+
+    preference_fields = {
+        "Price": ("slider", (0.0, 100.0, 20.0)),       # (min, max, default)
+        "CustomerRating": ("slider", (0.0, 5.0, 4.0)),
+        "FulfillmentSpeed": ("select", ["Same Day", "Next Day", "Two Day", "Standard"]),
+        "Availability": ("select", ["In Stock", "Out of Stock", "Limited Stock"]),
+        "Brand": ("text", ""),
+        "Container": ("select", ["N/A", "Box", "Bag", "Bottle", "Carton", "Jar"]),
+        "Form": ("select", ["N/A", "Whole", "Sliced", "Powder", "Liquid", "Granulated"]),
+        "Departments": ("text", "Grocery"),
+        "Category": ("text", ""),
+        "MeatType": ("select", ["N/A", "Chicken", "Beef", "Pork", "Turkey", "Fish", "Seafood"]),
+        "SpecialDietNeeds": ("select", ["None", "Gluten-Free", "Vegan", "Keto-Friendly", "Organic", "Vegetarian"]),
+    }
+
+    st.write("Use these controls to set default preferences.")
+
+    for field_name, field_type_info in preference_fields.items():
+        control_type = field_type_info[0]
+        if control_type == "slider":
+            min_val, max_val, default_val = field_type_info[1]
+            current_value = user_prefs["field_values"].get(field_name, default_val)
+            slider_val = st.slider(
+                field_name,
+                min_value=min_val,
+                max_value=max_val,
+                value=float(current_value),
+                step=0.1,
+            )
+            user_prefs["field_values"][field_name] = slider_val
+
+        elif control_type == "select":
+            options = field_type_info[1]
+            stored_val = user_prefs["field_values"].get(field_name, options[0])
+            if stored_val not in options:
+                stored_val = options[0]
+            select_val = st.selectbox(field_name, options, index=options.index(stored_val))
+            user_prefs["field_values"][field_name] = select_val
+
+        elif control_type == "text":
+            default_text = field_type_info[1] if len(field_type_info) > 1 else ""
+            current_text = user_prefs["field_values"].get(field_name, default_text)
+            text_val = st.text_input(field_name, value=current_text)
+            user_prefs["field_values"][field_name] = text_val
+
+    # Save/Load Buttons
+    st.write("---")
+    if st.button("Save Preferences"):
+        st.success("Preferences saved (in memory).")
+
+    if st.button("Load Preferences"):
+        st.info("Preferences reloaded from session state.")
+        st.experimental_rerun()
+
+    # Display Current Values
+    st.subheader("Current Preference Values")
+    st.json(user_prefs["field_values"])
+
+    # Simulate a search with these preferences
+    if st.button("Simulate a Walmart API Search Using My Preferences"):
+        brand_filter = user_prefs["field_values"].get("Brand", "")
+        max_price = user_prefs["field_values"].get("Price", 20.0)
+        min_rating = user_prefs["field_values"].get("CustomerRating", 0.0)
+        st.write(f"**Simulating** with brand='{brand_filter}', price<={max_price}, rating>={min_rating}")
+        mock_data = {
+            "search_query": brand_filter,
+            "price_limit": max_price,
+            "min_rating": min_rating,
+            "results": [
+                {"itemName": "Mock Pref Product 1", "price": 19.99, "rating": 4.2},
+                {"itemName": "Mock Pref Product 2", "price": 9.99, "rating": 4.0},
+            ]
+        }
+        st.json(mock_data)
+
+else:
+    st.info("Enter a username above to enable saving/loading preferences.")


### PR DESCRIPTION
The script is a Streamlit web app that lets a user:
	1.	Upload a recipe file (PDF or TXT).
	•	The file is parsed once (cached) to extract text and show any lines that look like an ingredients list.
	2.	Search Walmart’s catalog (demo‑mode).
	•	A dropdown lets the user choose a Walmart product field, enter a value, and view a mock API response.
	3.	Set and save personal shopping preferences (price range, rating threshold, brand, diet needs, etc.).
	•	Sliders, select‑boxes, and text inputs store the settings in st.session_state, so the user can reload or use them to simulate a filtered search.
	4.	Run efficiently.
	•	@st.cache_data prevents re‑parsing the same PDF, and installing Watchdog speeds up Streamlit’s file‑watching on macOS.

In short, it’s a demo UI that merges recipe‑ingredient extraction with Walmart‑style product search and preference management, optimized for faster reloads.